### PR TITLE
Add initial custom name property and support for more than one loadpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,12 +24,29 @@ rm main.zip
 Within the project there is a file `/data/dbus-evcc/config.ini` - just change the values - most important is the deviceinstance under "DEFAULT" and host in section "ONPREMISE". More details below:
 
 | Section  | Config vlaue | Explanation |
+| Section  | Config value | Explanation |
 | ------------- | ------------- | ------------- |
 | DEFAULT  | AccessType | Fixed value 'OnPremise' |
 | DEFAULT  | SignOfLifeLog  | Time in minutes how often a status is added to the log-file `current.log` with log-level INFO |
 | DEFAULT  | Deviceinstance | Unique ID identifying the charger in Venus OS |
 | ONPREMISE  | Host | IP or hostname of EVCC |
 
+## If you have two load points in EVCC
+1. Follow the installation instructions above, but change the commands as follows:
+   ```
+   wget https://github.com/SamuelBrucksch/dbus-evcc/archive/refs/heads/main.zip
+   unzip main.zip "dbus-evcc-main/*" -d /data
+   mv /data/dbus-evcc-main /data/dbus-evcc-1
+   chmod a+x /data/dbus-evcc-1/install.sh
+   /data/dbus-evcc-1/install.sh
+   rm main.zip
+   ```
+   (Count up `dbus-evcc-1` for each loadpoint)
+2. Update the `dbus-evcc-1/config.ini`:
+   - The `deviceinstance` should be different for each loadpoint: Use `43` for the first. Use `44` for the second loadpoint...
+   - The `loadpointInstance` should be different for each loadpoint: Use `0` for the first. Use `1` for the second loadpoint...
+
+If you have more than two loadpoints, the procedure is the same, but the indexes should be counted up.
 
 ## Useful links
 Many thanks. @vikt0rm, @fabian-lauer, @trixing and @JuWorkshop project:

--- a/config.ini
+++ b/config.ini
@@ -1,7 +1,8 @@
 [DEFAULT]
 AccessType = OnPremise
 SignOfLifeLog = 1
-Deviceinstance = 43
+Deviceinstance = 43 #Default = 43. Count up for every additional loadpoint
+LoadpointInstance = 0 #Read readme.md first! Default = 0. Count up for every additional loadpoint
 
 [ONPREMISE]
 Host=192.168.1.2:7070

--- a/dbus-evcc.py
+++ b/dbus-evcc.py
@@ -37,6 +37,11 @@ class DbusEvccChargerService:
 
         # get data from go-eCharger
         data = self._getEvccChargerData()
+        result = data["result"]
+        loadpoint = result["loadpoints"][0]
+
+        # Set custom name from loadpoint title
+        customname = str(loadpoint['title'])
 
         # Create the management objects, as specified in the ccgx dbus-api document
         self._dbusservice.add_path('/Mgmt/ProcessName', __file__)
@@ -48,7 +53,7 @@ class DbusEvccChargerService:
         self._dbusservice.add_path('/DeviceInstance', deviceinstance)
         self._dbusservice.add_path('/ProductId', 0xFFFF)  #
         self._dbusservice.add_path('/ProductName', productname)
-        self._dbusservice.add_path('/CustomName', productname)
+        self._dbusservice.add_path('/CustomName', customname)
         #self._dbusservice.add_path('/FirmwareVersion', int(data['divert_update']))
         self._dbusservice.add_path('/HardwareVersion', 2)
         #self._dbusservice.add_path('/Serial', data['comm_success'])

--- a/dbus-evcc.py
+++ b/dbus-evcc.py
@@ -24,6 +24,7 @@ class DbusEvccChargerService:
     def __init__(self, servicename, paths, productname='EVCC-Charger', connection='EVCC REST API'):
         config = self._getConfig()
         deviceinstance = int(config['DEFAULT']['Deviceinstance'])
+        lpInstance = int(config['DEFAULT']['LoadpointInstance'])
 
         self._dbusservice = VeDbusService("{}.http_{:02d}".format(servicename, deviceinstance))
         self._paths = paths
@@ -38,7 +39,7 @@ class DbusEvccChargerService:
         # get data from go-eCharger
         data = self._getEvccChargerData()
         result = data["result"]
-        loadpoint = result["loadpoints"][0]
+        loadpoint = result["loadpoints"][lpInstance]
 
         # Set custom name from loadpoint title
         customname = str(loadpoint['title'])
@@ -136,7 +137,7 @@ class DbusEvccChargerService:
             # get data from go-eCharger
             data = self._getEvccChargerData()
             result = data["result"]
-            loadpoint = result["loadpoints"][0]
+            loadpoint = result["loadpoints"][lpInstance]
 
             # send data to DBus
 


### PR DESCRIPTION
If you're using more than one instance, it may be useful to set an initial custom name. This PR reads the title from EVCC and sets it as the custom name. Changes in EVCC would then be reflected in VRM:

<img width="528" alt="Bildschirmfoto 2024-03-15 um 13 15 44" src="https://github.com/SamuelBrucksch/dbus-evcc/assets/44921964/f95f975d-c8a6-4a85-94a3-a5e4a6a20f47">
